### PR TITLE
Remove node status

### DIFF
--- a/src/atomic_quad_tree.h
+++ b/src/atomic_quad_tree.h
@@ -7,19 +7,6 @@
 
 #include "system.h"
 
-// define sentinel value
-template<typename Index_t>
-constexpr Index_t is_leaf = static_cast<Index_t>(-1);
-
-// phases that nodes in the tree can go through
-enum class NodeStatus : uint32_t {
-    Locked,
-    EmptyLeaf,
-    FullLeaf,
-    NotLeaf,
-};
-static_assert(atomic<NodeStatus>::is_always_lock_free);
-
 // Quad tree using Class of Vectors (CoV) (i.e. Structure of Arrays)
 template<typename T, typename Index_t>
 class AtomicQuadTree {
@@ -30,7 +17,6 @@ public:
     Index_t* first_child;
     Index_t* next_nodes;
     Index_t* parent;
-    atomic<NodeStatus>* node_status;
     // bump ptr used to keep track of allocated nodes
     atomic<Index_t>* bump_allocator;
 
@@ -40,12 +26,15 @@ public:
     // used for mass calc
     atomic<Index_t>* child_mass_complete;  // stores number of children that have correct mass
 
+    static constexpr Index_t empty = std::numeric_limits<Index_t>::max();
+    static constexpr Index_t body = empty - 1;
+    static constexpr Index_t locked = body - 1;
+
     void clear(Index_t i) {
       if (i == 0) bump_allocator->store(1, memory_order_relaxed);
-      first_child[i] = is_leaf<Index_t>;
-      next_nodes[i] = is_leaf<Index_t>;
-      parent[i] = is_leaf<Index_t>;
-      node_status[i].store(NodeStatus::EmptyLeaf, memory_order_relaxed);
+      first_child[i] = empty;
+      next_nodes[i] = empty;
+      parent[i] = empty;
       total_masses[i] = T(0);
       centre_masses[i] = vec<T, 2>::splat(0);
       child_mass_complete[i].store(0, memory_order_relaxed);
@@ -57,7 +46,6 @@ public:
       qt.first_child = new Index_t[size];
       qt.next_nodes = new Index_t[size];
       qt.parent = new Index_t[size];
-      qt.node_status = new atomic<NodeStatus>[size];
       qt.bump_allocator = new atomic<Index_t>(1);
 
       qt.total_masses = new T[size];
@@ -71,7 +59,6 @@ public:
       delete[] qt->first_child;
       delete[] qt->next_nodes;
       delete[] qt->parent;
-      delete[] qt->node_status;
       delete[] qt->total_masses;
       delete[] qt->centre_masses;
       delete[] qt->child_mass_complete;


### PR DESCRIPTION
This PR removes the `node_status` by encoding whether a node is empty, locked, or contains a body inside `first_child`.