### PR TITLE
Workaround clang iota view issue with BabelStream ranged class

### DIFF
--- a/src/all_pairs.h
+++ b/src/all_pairs.h
@@ -26,14 +26,9 @@ void all_pairs_force(System<T, N>& system) {
 
 template <typename T, dim_t N>
 void all_pairs_collapsed_force(System<T, N>& system) {
-#if !defined(__ACPP__)
+
   auto it = counting_iterator<uint64_t>(0);
   std::for_each_n(par_unseq, it, system.size * system.size, [s = system.state()](auto p) {
-#else
-  static uint64_t* ptr = new uint64_t(0);
-  std::for_each_n(par_unseq, ptr, system.size * system.size, [s = system.state(), ptr = ptr](auto& ref) {
-    auto p = &ref - ptr;
-#endif
     auto j = p / s.sz;
     auto i = p % s.sz;
     if (i == j) {

--- a/src/counting_iterator.h
+++ b/src/counting_iterator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ranges>
+#include <limits>
 
 // Workaround for two nvc++ bugs:
 // - Not supporting 128-bit integers yet on GPUs,
@@ -9,11 +10,74 @@
   #include <thrust/iterator/counting_iterator.h>
 #endif
 
+
+// Workaround for compilers not supporting views::iota properly. Originally
+// from BabelStream.
+//
+// A lightweight counting iterator which will be used by the STL algorithms
+// NB: C++ <= 17 doesn't have this built-in, and it's only added later in ranges-v3 (C++2a) which this
+// implementation doesn't target
+template <typename N>
+class ranged {
+public:
+  class iterator {
+    friend class ranged;
+    public:
+    using difference_type = N;
+    using value_type = N;
+    using pointer = const N*;
+    using reference = N;
+    using iterator_category = std::random_access_iterator_tag;
+
+    // XXX This is not part of the iterator spec, it gets picked up by oneDPL if enabled.
+    // Without this, the DPL SYCL backend collects the iterator data on the host and copies to the device.
+    // This type is unused for any nother STL impl.
+    using is_passed_directly = std::true_type;
+
+    reference operator *() const { return i_; }
+    iterator &operator ++() { ++i_; return *this; }
+    iterator operator ++(int) { iterator copy(*this); ++i_; return copy; }
+
+    iterator &operator --() { --i_; return *this; }
+    iterator operator --(int) { iterator copy(*this); --i_; return copy; }
+
+    iterator &operator +=(N by) { i_+=by; return *this; }
+
+    value_type operator[](const difference_type &i) const { return i_ + i; }
+
+    difference_type operator-(const iterator &it) const { return i_ - it.i_; }
+    iterator operator+(const value_type v) const { return iterator(i_ + v); }
+
+    bool operator ==(const iterator &other) const { return i_ == other.i_; }
+    bool operator !=(const iterator &other) const { return i_ != other.i_; }
+    bool operator < (const iterator &other) const { return i_ < other.i_; }
+
+    protected:
+      explicit iterator(N start) : i_ (start) {}
+
+    private:
+        N i_;
+  };
+
+  [[nodiscard]] iterator begin() const { return begin_; }
+  [[nodiscard]] iterator end() const { return end_; }
+  ranged(N begin, N end) : begin_(begin), end_(end) {}
+private:
+  iterator begin_;
+  iterator end_;
+};
+
+
 template <typename T>
 constexpr auto counting_iterator(T v = T(0)) {
 #if defined(_NVHPC_STDPAR_GPU) || defined(_NVHPC_STDPAR_MULTICORE)
   return thrust::counting_iterator<T>(T(v));
+#elif defined(__clang__)
+  return ranged<T>{v, std::numeric_limits<T>::max()}.begin();
 #else
   return std::views::iota(T(v)).begin();
 #endif
 }
+
+
+


### PR DESCRIPTION
`all-pairs-collapsed` runs and offloads with this with AdaptiveCpp. I did not try all the other compilers, so please have a look to ensure that nothing breaks.