### PR TITLE
Fix 2D compilation and Hilbert index calculation

### DIFF
--- a/src/hilbert_tree.h
+++ b/src/hilbert_tree.h
@@ -48,7 +48,7 @@ void hilbert_sort(System<T, N>& system, aabb<T, N> bbox) {
   // Workaround: copy everything to a vector of tuples (allocated only once), sort that, then copy things back
   // TODO: sort an array of keys and then apply a permutation in O(N) time and O(1) storage
   // (instead of O(N) time and O(N) storage).
-  static std::vector<std::tuple<uint64_t, vec<T, 3>, T, vec<T, 3>, vec<T, 3>, vec<T, 3>>> tmp(system.size);
+  static std::vector<std::tuple<uint64_t, vec<T, N>, T, vec<T, N>, vec<T, N>, vec<T, N>>> tmp(system.size);
   std::for_each(par_unseq, tmp.begin(), tmp.end(),
                 [tmp = tmp.data(), hid = hilbert_ids.data(), x = system.x.data(), m = system.m.data(),
                  v = system.v.data(), a = system.a.data(), ao = system.ao.data()](auto& e) {

--- a/src/vec.h
+++ b/src/vec.h
@@ -313,15 +313,17 @@ uint64_t hilbert(vec<uint32_t, N> x) {
           x[i] ^= t;
         }
       }  // exchange
-
-      // Gray encode
-      for (uint32_t i = 1; i < n; ++i) x[i] ^= x[i - 1];
-      uint32_t t = 0;
-      for (uint32_t Q = M; Q > 1; Q >>= 1)
-        if ((x[n - 1] & Q) != 0) t ^= Q - 1;
-      for (uint32_t i = 0; i < n; ++i) x[i] ^= t;
-      return interleave_bits(x);
     }
+
+    // Gray encode
+    for (uint32_t i = 1; i < n; ++i) x[i] ^= x[i - 1];
+    uint32_t t = 0;
+    for (uint32_t Q = M; Q > 1; Q >>= 1)
+      if ((x[n - 1] & Q) != 0) t ^= Q - 1;
+    for (uint32_t i = 0; i < n; ++i) x[i] ^= t;
+    
+    return interleave_bits(x);
+  
   } else if constexpr (N == 3) {
     constexpr int32_t n = 2, bits = 21;
     constexpr uint32_t M = 1U << (bits - 1);


### PR DESCRIPTION
The issues with hilbert tree and tuple that I encountered are because I tried to build with `-DDIM_SIZE=2`. However, apparently the 2D case was broken because the tuple workaround in the Hilbert tree had the 3D case hardcoded.

Not sure if need the 2D case at all, but if we have this `DIM_SIZE` macro, I suppose we should ensure that it works as expected and does not break compilation :-)

This PR fixes the hardcoded 3D case in the Hilbert tree, and it also changes the Hilbert index calculation in the 2D case. No guarantees that the new calculation is 100% correct, but the previous code clearly had incorrect braces. I have changed the 2D code to do what I believe happens in the original version in SpatialCL.