### PR TITLE
Add format shim for compat with libstdc++ 12

### DIFF
--- a/src/all_pairs.h
+++ b/src/all_pairs.h
@@ -9,6 +9,7 @@
 #include "saving.h"
 #include "system.h"
 #include "timer.h"
+#include "format.h"
 
 template <typename T, dim_t N>
 void all_pairs_force(System<T, N>& system) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include "format.h"
 
 enum class SimulationType {
   Uniform,
@@ -139,7 +140,7 @@ inline auto parse_args(std::vector<std::string>&& args) {
                "--help\t\tDisplay this help message and quit\n");
       exit(EXIT_SUCCESS);
     } else {
-      cout << format("Unknown argument: '{}'\n", args[arg_index]);
+      cout << std::format("Unknown argument: '{}'\n", args[arg_index]);
       exit(EXIT_FAILURE);
     }
   }

--- a/src/barnes_hut.h
+++ b/src/barnes_hut.h
@@ -8,6 +8,7 @@
 #include "saving.h"
 #include "system.h"
 #include "timer.h"
+#include "format.h"
 
 template <typename T, dim_t N>
 void run_barnes_hut(System<T, N>& system, Arguments arguments) {

--- a/src/format.h
+++ b/src/format.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef FMT_FORMAT_WORKAROUND
+#include <fmt/core.h>
+namespace std {
+  using namespace fmt;
+}
+#else
+#include <format>
+#endif
+

--- a/src/hilbert_tree.h
+++ b/src/hilbert_tree.h
@@ -8,6 +8,7 @@
 #include "execution.h"
 #include "saving.h"
 #include "system.h"
+#include "format.h"
 
 using clock_timer = std::chrono::steady_clock;
 

--- a/src/models.h
+++ b/src/models.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <format>
+
+#include "format.h"
 #include <stdexcept>
 
 #include "arguments.h"

--- a/src/saving.h
+++ b/src/saving.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <fstream>
 
+#include "format.h"
 #include "arguments.h"
 #include "system.h"
 


### PR DESCRIPTION
Compile with `-DFMT_FORMAT_WORKAROUND` to make the code use `fmt::format` instead of `std::format`. This makes it work with libstdc++ 12 with AdaptiveCpp, which is more easy to setup due to availability in Ubuntu 22.04.