### PR TITLE
Some minor updates to recipe.py for AdaptiveCpp

### DIFF
--- a/ci/recipe.py
+++ b/ci/recipe.py
@@ -48,10 +48,10 @@ Stage0 += shell(commands=[
     'pip install numpy matplotlib gdown jupyterlab ipywidgets pandas seaborn conan jupyterlab-nvidia-nsight',
 ])
 
-# Install OneAPI and ROCm on x86_64 builds:
+# Install Intel OpenCL and ROCm on x86_64 builds:
 acpp_flags=''
 if True and arch == 'x86_64':
-    # Install OneAPI:
+    # Install Intel OpenCL:
     Stage0 += shell(commands=[
         'set -ex',
         'mkdir -p /var/tmp',
@@ -78,18 +78,16 @@ if True and arch == 'x86_64':
         'apt-get update',
         'apt-get install -y rocm-dev',
     ])
-    acpp_flags += '-DWITH_ONEAPI_BACKEND=ON -DWITH_ROCM_BACKEND=ON'
+    acpp_flags += '-DWITH_OPENCL_BACKEND=ON -DWITH_ROCM_BACKEND=ON'
 
 # Install and configure AdaptiveCpp:
 if True:
     Stage0 += shell(commands=[
         'set -ex',
-        # Need this for AdaptiveCpp to find LLVM
-        f'ln -sf /usr/lib/llvm-{llvm_ver}/lib/libLLVM-{llvm_ver}.so /usr/lib/llvm-{llvm_ver}/lib/libLLVM.so',
-        'git clone --recurse-submodules -b develop https://github.com/AdaptiveCpp/AdaptiveCpp',
+        'git clone -b nbody https://github.com/AdaptiveCpp/AdaptiveCpp',
         'cd AdaptiveCpp',
         'git submodule update --recursive',
-        f'cmake -Bbuild -H.  -DCMAKE_C_COMPILER="$(which clang-{llvm_ver})" -DCMAKE_CXX_COMPILER="$(which clang++-{llvm_ver})" -DCMAKE_INSTALL_PREFIX=/opt/adaptivecpp  -DWITH_CUDA_BACKEND=ON  -DWITH_CPU_BACKEND=ON',
+        f'cmake -Bbuild -H.  -DCMAKE_C_COMPILER="$(which clang-{llvm_ver})" -DCMAKE_CXX_COMPILER="$(which clang++-{llvm_ver})" -DCMAKE_INSTALL_PREFIX=/opt/adaptivecpp  -DWITH_CUDA_BACKEND=ON',
         'cmake --build build --target install -j $(nproc)',
     ])
     Stage0 += environment(variables={


### PR DESCRIPTION
- We are only installing Intel OpenCL, not the full oneAPI stack (we don't actually need all the gigabytes of the full oneAPI basekit)
- The correct AdaptiveCpp cmake flag is `-DWITH_OPENCL_BACKEND`
- CPU backend is always enabled and does not need to manually enabled
- Correct AdaptiveCpp branch is `nbody`, which also includes the hacky PTX inline assembly for the atomics
- `recurse-submodules` is not not needed
- Recent `develop` and `nbody` branch include a fix that should let it find `libLLVM-18.so`, so the symlink should no longer be needed: https://github.com/AdaptiveCpp/AdaptiveCpp/pull/1551


In general, the `-DWITH_*_BACKEND` flags are typically unneeded as, especially when installing CUDA/ROCm/OpenCL using official packages, AdaptiveCpp cmake will auto-detect and auto-enable them - but it doesn't hurt :)

I haven't touched the LLVM version, but I'm pretty sure we will have to touch that eventually and use 17 for AdaptiveCpp. I cannot guarantee that AMD with LLVM 18 will be reliable. JIT compilation could break any time with any change to source code. That setup breaks LLVM IR compatibility guarantees between different LLVM IR versions (ingesting LLVM IR generated by an older LLVM version is supported, but the reverse is not and generally breaks with every LLVM release *somewhere*).