### PR TITLE
Substantial Hilbert tree improvement: Improve distance threshold calculation & memory access pattern

### DIFF
--- a/src/hilbert_tree.h
+++ b/src/hilbert_tree.h
@@ -150,7 +150,7 @@ struct bvh {
   }
 
   static constexpr T mass(monopole m) {
-    return m[3];
+    return m[N];
   }
 
   static constexpr vec<T,N> position(monopole m) {

--- a/src/hilbert_tree.h
+++ b/src/hilbert_tree.h
@@ -223,17 +223,18 @@ struct bvh {
     }
   }
 
-  static constexpr bool can_approximate(vec<T, N> xs, vec<T, N> xj, aabb<T, N> b, T theta) {
+  static constexpr bool can_approximate(vec<T, N> xs, vec<T, N> xj, aabb<T, N> b, T theta_squared) {
     auto lengths = b.lengths();
     T max_length = lengths[0];
     for (dim_t i = 1; i < N; ++i)
       if (lengths[i] > max_length) max_length = lengths[i];
 
-    return (max_length * max_length) / dist2(xs, xj) < theta * theta;
+    return (max_length * max_length)  < theta_squared * dist2(xs, xj);
   }
 
   // Compute the force for each body
   void compute_force(System<T, N>& system, T theta) {
+    T theta_squared = theta * theta;
     node_t nbodies         = system.size;
     constexpr node_t empty = std::numeric_limits<node_t>::max();
     auto ids               = system.body_indices();
@@ -294,7 +295,7 @@ struct bvh {
           vec<T, N> xj = x[tree_index];
           T mj         = m[tree_index];
 
-          if (can_approximate(xs, xj, b[tree_index], theta)) {
+          if (can_approximate(xs, xj, b[tree_index], theta_squared)) {
             // below threshold
             a += mj * (xj - xs) / dist3(xs, xj);
             num_covered_particles += ncontained_leaves_at_level(level, nlevels);

--- a/src/vec.h
+++ b/src/vec.h
@@ -233,7 +233,7 @@ template <typename T, dim_t N>
 constexpr T dist2(vec<T, N> a, vec<T, N> b) {
   T tmp = T(0.);
   for (dim_t i = 0; i < N; ++i) {
-    T di = std::abs(a[i] - b[i]);
+    T di = a[i] - b[i];
     tmp += di * di;
   }
   return tmp;


### PR DESCRIPTION
* Avoid loading full bb: We actually only need the node width in `compute_forces`, not the full min and max corners of the bb, so this PR just calculates the node width at tree construction. During `compute_forces` we then only load the node width. With this, instead of loading `6 * sizeof(T)` bytes we only load `sizeof(T)` per distance threshold calculation.
* Avoid divide and `std::abs` calls in distance threshold by reformulating the equation


With this, time per step for 7 million particles drops from 2.8s to 1.8s on my GPU with theta=0.5. **(outdated, see EDIT)**

Not sure if we need to include this in the paper, as most of our conclusions likely won't change. Maybe useful for future work, or for the camera ready version.

EDIT: I've added an additional improvement. We are now no longer storing monopole mass and position separately, but instead using a single 4-component vector to store both (in 3D case). This not only simplifies memory access pattern, it also causes our `vec` objects to become aligned such that compilers can emit vector loads. With this, time per step drops further to 1.3s..